### PR TITLE
Dispatch your reducer instead of type:string combineReducers example.

### DIFF
--- a/src/actions/CounterActions.js
+++ b/src/actions/CounterActions.js
@@ -1,19 +1,23 @@
 /* @flow */
 
-import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../constants/actionTypes';
 import type { Action } from '../types/Action';
 import type { Dispatch, GetState } from '../types/Store';
+import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../reducers/counter';
 
-export function increment(amount: number): Action {
+export function increment(amount: number): Action<*> {
   return {
-    type: INCREMENT_COUNTER,
+    reducer: {
+      counter: INCREMENT_COUNTER
+    },
     payload: amount,
   };
 }
 
-export function decrement(amount: number): Action {
+export function decrement(amount: number): Action<*> {
   return {
-    type: DECREMENT_COUNTER,
+    reducer: {
+      counter: DECREMENT_COUNTER
+    },
     payload: amount,
   };
 }

--- a/src/constants/actionTypes.js
+++ b/src/constants/actionTypes.js
@@ -1,5 +1,0 @@
-/* @flow */
-
-export const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
-
-export const DECREMENT_COUNTER = 'DECREMENT_COUNTER';

--- a/src/reducers/counter.js
+++ b/src/reducers/counter.js
@@ -1,17 +1,12 @@
 /* @flow */
+export type State = number;
+const initialState: State = 0
+export default initialState
 
-import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../constants/actionTypes';
-import type { Action } from '../types/Action';
+export function INCREMENT_COUNTER (state: State, payload: number): State {
+  return state + payload
+}
 
-type State = number;
-
-export default function counter(state: State = 0, action: Action) {
-  switch (action.type) {
-    case INCREMENT_COUNTER:
-      return state + action.payload;
-    case DECREMENT_COUNTER:
-      return state - action.payload;
-    default:
-      return state;
-  }
+export function DECREMENT_COUNTER (state: State, payload: number): State {
+  return state - payload
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,12 +1,5 @@
-/* @flow */
-
-import { combineReducers } from 'redux';
-import counter from './counter';
-
-const reducers = {
-  counter,
-};
-
-export type Reducers = typeof reducers;
-
-export default combineReducers(reducers);
+export default function initialState () {
+  return {
+    counter: 0
+  }
+}

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,25 +1,62 @@
 /* @flow */
 
 import { createStore, applyMiddleware, compose } from 'redux';
+import type { StoreEnhancer } from 'redux'
 import thunk from 'redux-thunk';
-import rootReducer from '../reducers';
-import type { Store } from '../types/Store';
+import type { Store, Dispatch } from '../types/Store';
+import type { State } from '../types/State';
+import type { Action } from '../types/Action';
+import initialState from '../reducers'
 
-const composeEnhancers = process.env.NODE_ENV !== 'production'
+const dispatchReducerEnhancer: StoreEnhancer<State, Action<any>, Dispatch> =  (createStore) => {
+  return function (reducer): Store {
+    const store = createStore(reducer);
+    return {
+      ...store,
+      dispatch: (action: any) => {
+        if (
+          typeof action === 'object' &&
+          typeof action.reducer === 'object'
+        ) {
+          const keys = Object.keys(action.reducer)
+          if (keys.length >= 1) {
+            const type = action.reducer[keys[0]].name
+            action = {
+              ...action,
+              type
+            }
+          }
+        }
+        return store.dispatch(action)
+      }
+    };
+  }
+}
+
+function reducer (state: State, action: Action<any>): State {
+  if (!state) {
+    return initialState()
+  }
+  if (typeof action.reducer === 'object') {
+    const keys = Object.keys(action.reducer);
+    const newPartialState = keys.reduce((newPartialState, key) => {
+      newPartialState[key] = action.reducer[key](state[key], action.payload);
+      return newPartialState;
+    }, {});
+    return {
+      ...state,
+      ...newPartialState
+    };
+  }
+  return state;
+}
+
+const composeEnhancers = (process.env.NODE_ENV !== 'production')
   && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
   || compose;
-
-const enhancer = composeEnhancers(applyMiddleware(thunk));
+const enhancer = composeEnhancers(applyMiddleware(thunk), dispatchReducerEnhancer);
 
 export default function configureStore(): Store {
-  const store = createStore(rootReducer, enhancer);
-
-  if (process.env.NODE_ENV !== 'production' && module.hot) {
-    /* $FlowFixMe */
-    module.hot.accept('../reducers', () =>
-      store.replaceReducer(require('../reducers').default)
-    );
-  }
-
+  const store = enhancer(createStore)(reducer);
   return store;
 }

--- a/src/types/Action.js
+++ b/src/types/Action.js
@@ -1,13 +1,10 @@
 /* @flow */
 
-export type IncrementAction = {
-  type: 'INCREMENT_COUNTER',
-  payload: number,
-};
+import type { Reducer } from './Reducer';
 
-export type DecrementAction = {
-  type: 'DECREMENT_COUNTER',
-  payload: number,
-};
-
-export type Action = IncrementAction | DecrementAction;
+export type Action<P> = {
+  reducer: {
+    [string]: Reducer<any, P>
+  },
+  payload: P
+}

--- a/src/types/Reducer.js
+++ b/src/types/Reducer.js
@@ -1,0 +1,3 @@
+// @flow
+
+export type Reducer<S, P> = (state: S, payload: P) => S

--- a/src/types/State.js
+++ b/src/types/State.js
@@ -1,7 +1,6 @@
 /* @flow */
+import type { State as Counter } from '../reducers/counter';
 
-import type { Reducers } from '../reducers';
-
-type $ExtractFunctionReturn = <V>(v: (...args: any) => V) => V;
-
-export type State = $ObjMap<Reducers, $ExtractFunctionReturn>;
+export type State = {
+  counter: Counter
+}

--- a/src/types/Store.js
+++ b/src/types/Store.js
@@ -1,17 +1,14 @@
 /* @flow */
 
-import type {
-  /* eslint-disable import/named */
-  Store as ReduxStore,
-  Dispatch as ReduxDispatch,
-} from 'redux';
+import type { Store as ReduxStore } from 'redux'
 import type { Action } from './Action';
 import type { State } from './State';
 
-export type Store = ReduxStore<State, Action>;
-
 export type GetState = () => State;
 
-export type Dispatch = ReduxDispatch<Action> & Thunk<Action>;
+type ActionDispatch = <T>(action: Action<T>) => void;
+export type Thunk = ((Dispatch, GetState) => Promise<void> | void) => void;
 
-export type Thunk<A> = ((Dispatch, GetState) => Promise<void> | void) => A;
+export type Dispatch = ActionDispatch & Thunk;
+
+export type Store = ReduxStore<State, Action<any>, Dispatch>


### PR DESCRIPTION
This uses the following format to account for reducers written using combineReducers
```jsx
dispatch({
  reducer: {
    counter: INCREMENT_COUNTER
  },
  payload: amount
})
```
which I realized can be a bit cumbersome. A better approach would be to convert your reducers to expect the full state instead of a partial state. This I imagine should be easy to transform to using codemods. TODO: write code for that.